### PR TITLE
type수정

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ export interface OnCompleteParams {
   /**
    * 국가기초구역번호. 2015년 8월 1일부터 시행될 새 우편번호.
    */
-  zonecode: number;
+  zonecode: string;
 
   /**
    * 기본 주소


### PR DESCRIPTION
06135 와 같은 우편번호는 number 타입으로는 제대로 나오지 않습니다.
때문에 zonecode의 타입을 string으로 수정할 필요가 있습니다.